### PR TITLE
sensor with onCollision

### DIFF
--- a/public/constant.js
+++ b/public/constant.js
@@ -29,6 +29,17 @@ export const gameResultType = {
     LOSE: "lose",
 }
 
+export const bodyLabel = {
+    PLAYER: "player",
+    PLAYER_SENSOR: "player_sensor",
+}
+
+export const bodyCategory = {
+    BODY: 1,
+    SENSOR: 2,
+    SENSOR_TARGET: 4,
+}
+
 export const constant = {
     playerCnt: 1,
     clientLerp: 0.3,

--- a/public/server/entity/bullet.js
+++ b/public/server/entity/bullet.js
@@ -1,6 +1,6 @@
 import { Entity } from "./entity.js";
-import { entityType, playerType } from "../../constant.js";
-import { serverService } from "../server.js";
+import { bodyLabel, entityType, playerType } from "../../constant.js";
+import { serverData, serverService } from "../server.js";
 
 export class Bullet extends Entity {
     constructor(x = 0, y = 0, dx, dy) {
@@ -22,7 +22,14 @@ export class Bullet extends Entity {
         }, 1000);
     }
 
-    onCollision(target){
+    /**
+     * @param {Matter.Body} myBody 
+     * @param {Matter.Body} targetBody 
+     */
+    onCollision(myBody, targetBody){
+        if (targetBody.label !== bodyLabel.PLAYER)
+            return;
+        const target = serverData.entityBodyMap[targetBody.id];
         if (target.playerType !== playerType.POLICE)
             serverService.removeEntity(this);
     }

--- a/public/server/entity/door.js
+++ b/public/server/entity/door.js
@@ -1,12 +1,16 @@
 import { Entity } from "./entity.js";
-import { constant, entityType, input } from "../../constant.js";
+import { constant, entityType, input, bodyCategory, bodyLabel } from "../../constant.js";
+import { serverData } from "../server.js";
 
 export class Door extends Entity {
     constructor(x, y, code) {
         super(Matter.Bodies.rectangle(x, y,
             constant.blockCenter,
             constant.blockCenter,
-            { isStatic: true },
+            {
+                isStatic: true,
+                collisionFilter: { category: bodyCategory.SENSOR_TARGET }
+            },
         ));
         this.entityType = entityType.DOOR;
         this.body.label = entityType.DOOR;
@@ -43,7 +47,14 @@ export class Door extends Entity {
         }
     }
 
-    onCollision(target) {
+    /**
+     * @param {Matter.Body} myBody 
+     * @param {Matter.Body} targetBody 
+     */
+    onCollision(myBody, targetBody) {
+        if (targetBody.label !== bodyLabel.PLAYER_SENSOR)
+            return;
+        const target = serverData.entityBodyMap[targetBody.id];
         if (target.entityType == entityType.PLAYER && target.key[input.INTERACT] == true)
             this.interact();
     };

--- a/public/server/entity/entity.js
+++ b/public/server/entity/entity.js
@@ -1,6 +1,7 @@
 import { entityType } from "../../constant.js";
 
 export class Entity {
+    static nextGroupId = -1;
     /**
      * @param {Matter.Body} body 
      */
@@ -28,5 +29,19 @@ export class Entity {
             y: this.body.position.y,
             isStatic: this.isStatic,
         }
+    }
+
+    /**
+     * @param {Matter.Body} myBody 
+     * @param {Matter.Body} targetBody 
+     */
+    onCollision(myBody, targetBody) {
+    }
+
+    /**
+     * @returns {number}
+     */
+    static getNextGroupId() {
+        return Entity.nextGroupId--;
     }
 }

--- a/public/server/entity/generator.js
+++ b/public/server/entity/generator.js
@@ -1,10 +1,12 @@
 import { Entity } from "./entity.js";
-import { constant, entityType, input } from "../../constant.js";
-import { serverService } from "../server.js";
+import { bodyCategory, bodyLabel, constant, entityType, input } from "../../constant.js";
+import { serverData } from "../server.js";
 
 export class Generator extends Entity {
     constructor(x, y, code) {
-        super(Matter.Bodies.rectangle(x, y, constant.blockCenter, constant.blockCenter, { isStatic: true }));
+        super(Matter.Bodies.rectangle(x, y, constant.blockCenter, constant.blockCenter, { isStatic: true, collisionFilter: {
+            category: bodyCategory.SENSOR_TARGET,
+        }}));
         this.entityType = entityType.GENERATOR;
         this.body.label = entityType.GENERATOR;
         this.wallCode = code;
@@ -74,7 +76,14 @@ export class Generator extends Entity {
         }
     }
 
-    onCollision(target) {
+    /**
+     * @param {Matter.Body} myBody 
+     * @param {Matter.Body} targetBody 
+     */
+    onCollision(myBody, targetBody) {
+        if (targetBody.label !== bodyLabel.PLAYER_SENSOR)
+            return;
+        const target = serverData.entityBodyMap[targetBody.id];
         if (target.entityType == entityType.PLAYER && target.key[input.INTERACT] == true)
             this.interact();
         if (target.entityType == entityType.PLAYER && target.key[input.INTERACT] == false)


### PR DESCRIPTION
server의 player entity를 여러개의 body로 구성할 수 있도록 변경하여
플레이어의 충돌범위보다 조금 넓은 sensor(body)영역을 생성하고
generator와 door와 적정거리에서 상호작용할 수 있도록 수정했습니다.